### PR TITLE
Fixed a bug where child parts were not visible when a sub-assembly was selected as a link.

### DIFF
--- a/SW2URDF/URDFExport/CommonSwOperations.cs
+++ b/SW2URDF/URDFExport/CommonSwOperations.cs
@@ -128,6 +128,31 @@ namespace SW2URDF.URDFExport
             model.ShowComponent2();
         }
 
+        //Shows the components in the list and its' children. Useful for exporting STLs
+        public static void ShowComponentsRecursive(ModelDoc2 model, List<Component2> components)
+        {
+            foreach (Component2 component in components)
+            {
+                int children_count = component.IGetChildrenCount();
+                if (children_count > 0)
+                {
+                    object[] child_objects = component.GetChildren();
+                    List<Component2> child_components = new List<Component2>();
+                    foreach(Component2 comp in child_objects)
+                    {
+                        child_components.Add(comp);
+                    }
+                    ShowComponentsRecursive(model, child_components);
+                }
+                else
+                {
+                    logger.Info($"Show component: {component.Name2}");
+                    List<Component2> component_list = new List<Component2>(){component};
+                    ShowComponents(model, component_list);
+                }
+            }
+        }
+
         //Hides the components from a list
         public static void HideComponents(ModelDoc2 model, List<Component2> components)
         {

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -351,7 +351,7 @@ namespace SW2URDF.URDFExport
 
             logger.Info(link.Name + ": Reference geometry name " + names["component"]);
 
-            CommonSwOperations.ShowComponents(ActiveSWModel, link.SWComponents);
+            CommonSwOperations.ShowComponentsRecursive(ActiveSWModel, link.SWComponents);
 
             int saveOptions = (int)swSaveAsOptions_e.swSaveAsOptions_Silent |
                 (int)swSaveAsOptions_e.swSaveAsOptions_Copy;
@@ -439,8 +439,7 @@ namespace SW2URDF.URDFExport
 
             logger.Info(link.Name + ": Reference geometry name " + names["component"]);
 
-            CommonSwOperations.ShowComponents(ActiveSWModel, link.SWComponents);
-
+            CommonSwOperations.ShowComponentsRecursive(ActiveSWModel, link.SWComponents);
             int saveOptions = (int)swSaveAsOptions_e.swSaveAsOptions_Silent |
                 (int)swSaveAsOptions_e.swSaveAsOptions_Copy;
             SetLinkSpecificSTLPreferences(names["geo"], link.STLQualityFine, ActiveDoc);

--- a/SW2URDF/URDFExport/ExportHelper.cs
+++ b/SW2URDF/URDFExport/ExportHelper.cs
@@ -401,7 +401,7 @@ namespace SW2URDF.URDFExport
                 {
                     logger.Info("Localizing Link : " + coordsysName);
                     Matrix<double> GlobalTransform = MathOps.GetTransformation(coordSysTransform);
-                    LocalizeLink(link, GlobalTransform);
+                    LocalizeLink(link, GlobalTransform, true);
                 }
                 else
                 {

--- a/SW2URDF/URDFExport/ExportHelperExtension.cs
+++ b/SW2URDF/URDFExport/ExportHelperExtension.cs
@@ -112,7 +112,8 @@ namespace SW2URDF.URDFExport
 
         //This is only used by the Part Exporter, but it localizes the link to the Origin_global
         // coordinate system
-        private static void LocalizeLink(Link Link, Matrix<double> GlobalTransform)
+        // OnlyVisualAndCollision: Option for exporting in 3dxml format.
+        private static void LocalizeLink(Link Link, Matrix<double> GlobalTransform, bool OnlyVisualAndCollision = false)
         {
             Matrix<double> GlobalTransformInverse = GlobalTransform.Inverse();
             Matrix<double> linkCoMTransform = MathOps.GetTranslation(Link.Inertial.Origin.GetXYZ());
@@ -139,13 +140,16 @@ namespace SW2URDF.URDFExport
             Matrix<double> linkLocalMomentInertia =
                 GlobalRotMat * linkGlobalMomentInertia * GlobalRotMat.Transpose();
 
-            Link.Inertial.Origin.SetXYZ(MathOps.GetXYZ(localLinkCoMTransform));
-            Link.Inertial.Origin.SetRPY(new double[] { 0, 0, 0 });
+            if (!OnlyVisualAndCollision)
+            { 
+                Link.Inertial.Origin.SetXYZ(MathOps.GetXYZ(localLinkCoMTransform));
+                Link.Inertial.Origin.SetRPY(new double[] { 0, 0, 0 });
 
-            // Wait are you saying that even though the matrix was trasposed from column major
-            // order, you are writing it in row-major order here. Yes, yes I am.
-            double[] moment = linkLocalMomentInertia.ToRowMajorArray();
-            Link.Inertial.Inertia.SetMomentMatrix(moment);
+                // Wait are you saying that even though the matrix was trasposed from column major
+                // order, you are writing it in row-major order here. Yes, yes I am.
+                double[] moment = linkLocalMomentInertia.ToRowMajorArray();
+                Link.Inertial.Inertia.SetMomentMatrix(moment);
+            }
 
             Link.Collision.Origin.SetXYZ(MathOps.GetXYZ(localCollisionTransform));
             Link.Collision.Origin.SetRPY(MathOps.GetRPY(localCollisionTransform));


### PR DESCRIPTION
This PR fixes a bug where, when a sub-assembly was selected as a link, its child parts were not included in the mesh and thus were not visible.
This PR enables correct mesh generation for a link by selecting the sub-assembly as a whole, eliminating the need to select each part within the sub-assembly individually.

This does not destroy the original functions.